### PR TITLE
mdm.rb: Change to SHA-256

### DIFF
--- a/Formula/mdm.rb
+++ b/Formula/mdm.rb
@@ -3,7 +3,7 @@ require "formula"
 class Mdm < Formula
   homepage "https://github.com/polydawn/mdm"
   url "https://github.com/mdm-releases/mdm-releases/blob/master/v2.19.1/mdm?raw=true", :using => :nounzip
-  sha1 "01e28b3508ae7da478fb15aeeb171113064eaa4a"
+  sha256 "74ec49f4930d6a00e5158e3e4c2e9963fb699d340b394c4fd31bcc28333b023f"
   version "2.19.1"
 
   def install


### PR DESCRIPTION
Blast from the past: I'm cleaning up some code and I came across an old repo with some mdm references in its `.gitmodules` file. Turns out I had deleted `mdm` from my machine a while back and need it again.